### PR TITLE
Introduce life-cycle-event-handler, introduce react bridge module, modify play-services dependency

### DIFF
--- a/Polyline.js
+++ b/Polyline.js
@@ -1,0 +1,64 @@
+'use strict';
+
+let React = require('react-native');
+
+let {
+  NativeModules
+} = React;
+
+var API = NativeModules.RNGMapsPolylineModule;
+
+class Polyline {
+  static create(options, callback) {
+    Object.assign(options||{}, {
+      name: this.constructor.name
+    });
+
+    options.points = options.points || [];
+
+    API.create(options, function(id) {
+      callback(new Polyline(id, options));
+    });
+  }
+  
+  constructor (id, config) {
+    this.id     = id;
+    this.color  = config.color;
+    this.points = config.points || [];
+    this.width  = config.width;
+  }
+
+  addPoint(lat, lng, callback) {
+    callback = callback || ()=>{};
+    this.points.push([lat, lng]);
+    API.setState(this._toMap(), callback);
+  }
+
+  setPoints(points, callback) {
+    callback = callback || ()=>{};
+    API.setState(this._toMap(), callback);
+  }
+
+  setState(config, callback) {
+    callback = callback || ()=>{};
+    Object.assign(this, config);
+    API.setState(this._toMap(), callback);
+  }
+
+  remove(callback) {
+    callback = callback || ()=>{};
+    API.remove(this.id, callback);
+  }
+  _toMap() {
+    return {
+      id: this.id,
+      color: this.color,
+      geodesic: this.geodesic,
+      visible: this.visible,
+      width: this.width,
+      points: this.points
+    }
+  }
+}
+
+module.exports = Polyline;

--- a/README.md
+++ b/README.md
@@ -42,6 +42,39 @@ Pass in a function to onMapError to respond to any errors thrown by gmaps. The o
 
 - **zoomOnMarkers** - Call this to zoom the map in on any markers you may have added.
 
+### API
+
+#### Polyline
+
+```
+
+var Polyline = require('react-native-gmaps/Polyline');
+
+Polyline.create({
+  color: '#0000cc',
+  width: 15,
+  geodesic: true,
+  visible: true,
+  points: [
+    [51.5, -0.1], [40.7, -74.0]
+  ]
+}, function(polyline) {
+  polyline.addPoint(45.5192919, -73.6169509, function(success) {
+    console.log("- addPoint success");
+  });
+
+  polyline.setState({
+    color: '#ff0000',
+    width: 20
+  }, function(success) {
+    console.log('- setState success');
+  });
+
+  // Remove it
+  polyline.remove();
+
+})
+```
 
 ### Install
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,6 +23,6 @@ dependencies {
   compile fileTree(dir: 'libs', include: ['*.jar'])
   testCompile 'junit:junit:4.12'
   compile 'com.android.support:appcompat-v7:23.1.0'
-  compile 'com.facebook.react:react-native:0.12.0'
-  compile 'com.google.android.gms:play-services:8.1.0'
+  compile 'com.facebook.react:react-native:0.14.+'
+  compile 'com.google.android.gms:play-services-maps:8.1.0'
 }

--- a/android/app/src/main/java/com/rota/rngmaps/RNGMapsModule.java
+++ b/android/app/src/main/java/com/rota/rngmaps/RNGMapsModule.java
@@ -2,7 +2,6 @@ package com.rota.rngmaps;
 
 import android.os.Handler;
 import android.os.Looper;
-
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;

--- a/android/app/src/main/java/com/rota/rngmaps/RNGMapsModule.java
+++ b/android/app/src/main/java/com/rota/rngmaps/RNGMapsModule.java
@@ -1,205 +1,44 @@
-
 package com.rota.rngmaps;
 
-import android.util.Log;
+import android.os.Handler;
+import android.os.Looper;
 
-import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.Callback;
-import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.facebook.react.uimanager.CatalystStylesDiffMap;
-import com.facebook.react.uimanager.SimpleViewManager;
-import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.UIProp;
-import com.google.android.gms.maps.*;
-import com.google.android.gms.maps.model.CameraPosition;
-import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.LatLngBounds;
-import com.google.android.gms.maps.model.Marker;
-import com.google.android.gms.maps.model.MarkerOptions;
-
-import java.util.ArrayList;
-import java.util.Map;
 
 /**
- * Created by Henry on 08/10/2015.
+ * Created by chris scott<chris@transistorsoft.com> on 2015-11-21.
  */
+public class RNGMapsModule extends ReactContextBaseJavaModule {
+    public static final String REACT_CLASS = "RNGMapsModule";
 
-public class RNGMapsModule extends SimpleViewManager<MapView> {
-    public static final String REACT_CLASS = "RNGMaps";
-
-    private MapView mView;
-    private GoogleMap map;
-    private ReactContext reactContext;
-    private ArrayList<Marker> mapMarkers = new ArrayList<Marker>();
-
-    @UIProp(UIProp.Type.MAP)
-    public static final String PROP_CENTER = "center";
-
-    @UIProp(UIProp.Type.NUMBER)
-    public static final String PROP_ZOOM_LEVEL = "zoomLevel";
-
-    @UIProp(UIProp.Type.ARRAY)
-    public static final String PROP_MARKERS = "markers";
-
-    @UIProp(UIProp.Type.BOOLEAN)
-    public static final String PROP_ZOOM_ON_MARKERS = "zoomOnMarkers";
-
+    private RNGMapsViewManager mView;
+    private Handler uiHandler;
+    public RNGMapsModule(ReactApplicationContext reactContext, RNGMapsViewManager view) {
+        super(reactContext);
+        mView = view;
+        uiHandler = new Handler(Looper.getMainLooper());
+    }
     @Override
     public String getName() {
         return REACT_CLASS;
     }
+    @ReactMethod
+    public void addMarker(final ReadableMap config) {
+        uiHandler.post(new AddMarkerTask(config));
+    }
 
-    @Override
-    protected MapView createViewInstance(ThemedReactContext context) {
-        reactContext = context;
-        mView = new MapView(context);
-        mView.onCreate(null);
-        mView.onResume();
-        map = mView.getMap();
-
-        if (map == null) {
-          sendMapError("Map is null", "map_null");
-        } else {
-          map.getUiSettings().setMyLocationButtonEnabled(false);
-          map.setMyLocationEnabled(true);
-
-          try {
-              MapsInitializer.initialize(context.getApplicationContext());
-              map.setOnCameraChangeListener(getCameraChangeListener());
-          } catch (Exception e) {
-              e.printStackTrace();
-              sendMapError("Map initialize error", "map_init_error");
-          }
+    private class AddMarkerTask implements Runnable {
+        private ReadableMap mConfig;
+        public AddMarkerTask(ReadableMap config) {
+            super();
+            mConfig = config;
         }
-
-        return mView;
-    }
-
-    private void sendMapError (String message, String type) {
-      WritableMap error = Arguments.createMap();
-      error.putString("message", message);
-      error.putString("type", type);
-
-      reactContext
-              .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-              .emit("mapError", error);
-    }
-
-    private GoogleMap.OnCameraChangeListener getCameraChangeListener() {
-        return new GoogleMap.OnCameraChangeListener() {
-            @Override
-            public void onCameraChange(CameraPosition position) {
-                WritableMap params = Arguments.createMap();
-                WritableMap latLng = Arguments.createMap();
-                latLng.putDouble("lat", position.target.latitude);
-                latLng.putDouble("lng", position.target.longitude);
-
-                params.putMap("latLng", latLng);
-                params.putDouble("zoomLevel", position.zoom);
-
-                reactContext
-                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                        .emit("mapChange", params);
-            }
-        };
-    }
-
-    private Boolean updateCenter (CatalystStylesDiffMap props) {
-        try {
-            CameraUpdate cameraUpdate;
-            Double lng = props.getMap(PROP_CENTER).getDouble("lng");
-            Double lat = props.getMap(PROP_CENTER).getDouble("lat");
-
-            if(props.hasKey(PROP_ZOOM_LEVEL)) {
-                int zoomLevel = props.getInt(PROP_ZOOM_LEVEL, 10);
-                cameraUpdate = CameraUpdateFactory
-                        .newLatLngZoom(
-                                new LatLng(lat, lng),
-                                props.getInt(PROP_ZOOM_LEVEL, 10)
-                        );
-            } else {
-                cameraUpdate = CameraUpdateFactory.newLatLng(new LatLng(lat, lng));
-            }
-
-            map.animateCamera(cameraUpdate);
-
-            return true;
-        } catch (Exception e) {
-            // ERROR!
-            e.printStackTrace();
-            return false;
+        @Override
+        public void run() {
+            mView.addMarker(mConfig);
         }
-    }
-
-    private Boolean updateMarkers (CatalystStylesDiffMap props) {
-        try {
-
-            // First clear all markers from the map
-            for (Marker marker: mapMarkers) {
-                marker.remove();
-            }
-            mapMarkers.clear();
-
-            // All markers to map
-            for (int i = 0; i < props.getArray(PROP_MARKERS).size(); i++) {
-                MarkerOptions options = new MarkerOptions();
-                ReadableMap marker = props.getArray(PROP_MARKERS).getMap(i);
-                if(marker.hasKey("coordinates")) {
-
-                    options.position(new LatLng(
-                                    marker.getMap("coordinates").getDouble("lat"),
-                                    marker.getMap("coordinates").getDouble("lng")
-                            )
-                    );
-
-                    if(marker.hasKey("title")) {
-                        options.title(marker.getString("title"));
-                    }
-                    mapMarkers.add(map.addMarker(options));
-
-                } else break;
-            }
-
-
-            return true;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return false;
-        }
-    }
-
-    private Boolean zoomOnMarkers () {
-        try {
-            int padding = 150;
-
-            LatLngBounds.Builder builder = new LatLngBounds.Builder();
-            for (Marker marker : mapMarkers) {
-                builder.include(marker.getPosition());
-            }
-            LatLngBounds bounds = builder.build();
-
-            CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, padding);
-            map.animateCamera(cu);
-            return true;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return false;
-        }
-    }
-
-    @Override
-    public void updateView(MapView view, CatalystStylesDiffMap props) {
-        super.updateView(view, props);
-        if (props.hasKey(PROP_CENTER)) updateCenter(props);
-        if (props.hasKey(PROP_ZOOM_LEVEL)) updateCenter(props);
-        if (props.hasKey(PROP_MARKERS)) updateMarkers(props);
-        if (props.hasKey(PROP_ZOOM_ON_MARKERS)&&props.getBoolean(PROP_ZOOM_ON_MARKERS, false)) {
-          zoomOnMarkers();
-        }
-
     }
 }

--- a/android/app/src/main/java/com/rota/rngmaps/RNGMapsPackage.java
+++ b/android/app/src/main/java/com/rota/rngmaps/RNGMapsPackage.java
@@ -24,6 +24,7 @@ public class RNGMapsPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new RNGMapsModule(reactApplicationContext, viewManager));
+        modules.add(new RNGMapsPolylineModule(reactApplicationContext, viewManager));
         return modules;
     }
     @Override

--- a/android/app/src/main/java/com/rota/rngmaps/RNGMapsPackage.java
+++ b/android/app/src/main/java/com/rota/rngmaps/RNGMapsPackage.java
@@ -15,15 +15,21 @@ import java.util.List;
  * Created by Henry on 08/10/2015.
  */
 public class RNGMapsPackage implements ReactPackage {
+    private RNGMapsViewManager viewManager;
+
+    public RNGMapsPackage() {
+        viewManager = new RNGMapsViewManager();
+    }
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
-        return new ArrayList<>();
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new RNGMapsModule(reactApplicationContext, viewManager));
+        return modules;
     }
-
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
         return Arrays.<ViewManager>asList(
-                new RNGMapsModule()
+                viewManager
         );
     }
 

--- a/android/app/src/main/java/com/rota/rngmaps/RNGMapsPolylineModule.java
+++ b/android/app/src/main/java/com/rota/rngmaps/RNGMapsPolylineModule.java
@@ -1,0 +1,152 @@
+package com.rota.rngmaps;
+
+import android.graphics.Color;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Polyline;
+import com.google.android.gms.maps.model.PolylineOptions;
+
+import java.util.ArrayList;
+
+/**
+ * Created by chris scott<chris@transistorsoft.com> on 2015-11-21.
+ */
+public class RNGMapsPolylineModule extends ReactContextBaseJavaModule {
+    public static final String REACT_CLASS = "RNGMapsPolylineModule";
+
+    private RNGMapsViewManager mView;
+    private Handler uiHandler;
+    private ArrayList<Polyline> polylines = new ArrayList<Polyline>();
+
+    public RNGMapsPolylineModule(ReactApplicationContext reactContext, RNGMapsViewManager view) {
+        super(reactContext);
+        mView = view;
+        uiHandler = new Handler(Looper.getMainLooper());
+    }
+    @ReactMethod
+    public void create(ReadableMap config, final Callback callback) {
+        final PolylineOptions options = new PolylineOptions();
+
+        if (config.hasKey("points")) {
+            ReadableArray rs = config.getArray("points");
+
+            ArrayList<LatLng> points = new ArrayList<LatLng>();
+            for (int i=0;i<rs.size();i++) {
+                ReadableArray point = rs.getArray(i);
+                points.add(new LatLng(point.getDouble(0), point.getDouble(1)));
+            }
+            options.addAll(points);
+        }
+        if (config.hasKey("width")) {
+            options.width(config.getInt("width"));
+        }
+        if (config.hasKey("color")) {
+            options.color(Color.parseColor(config.getString("color")));
+        }
+        if (config.hasKey("visible")) {
+            options.visible(config.getBoolean("visible"));
+        }
+        if (config.hasKey("zIndex")) {
+            options.zIndex((float) config.getDouble("zIndex"));
+        }
+        if (config.hasKey("geodesic")) {
+            options.geodesic(config.getBoolean("geodesic"));
+        }
+
+        uiHandler.post(new Runnable() {
+            public void run() {
+                Polyline polyline = mView.getMap().addPolyline(options);
+                polylines.add(polyline);
+                callback.invoke(polyline.getId());
+            }
+        });
+    }
+    @ReactMethod
+    public void setState(final ReadableMap config, final Callback callback) {
+        if (!config.hasKey("id")) {
+            callback.invoke(false);
+            return;
+        }
+        final Polyline polyline = findById(config.getString("id"));
+        if (polyline != null) {
+            uiHandler.post(new Runnable() {
+                public void run() {
+                    applyState(polyline, config);
+                    callback.invoke(true);
+                }
+            });
+        } else {
+            callback.invoke(false);
+        }
+    }
+
+    @ReactMethod
+    public void remove(String id, final Callback callback) {
+        final Polyline polyline = findById(id);
+        if (polyline != null) {
+            uiHandler.post(new Runnable() {
+                public void run() {
+                    polyline.remove();
+                    callback.invoke(true);
+                }
+            });
+        } else {
+            callback.invoke(false);
+        }
+    }
+    @Override
+    public String getName() {
+        return REACT_CLASS;
+    }
+
+    private void applyState(Polyline polyline, ReadableMap config) {
+        if (config.hasKey("points")) {
+            ReadableArray rs = config.getArray("points");
+            ArrayList<LatLng> points = new ArrayList<LatLng>();
+            for (int i=0;i<rs.size();i++) {
+                ReadableArray point = rs.getArray(i);
+                points.add(new LatLng(point.getDouble(0), point.getDouble(1)));
+            }
+            polyline.setPoints(points);
+        }
+        if (config.hasKey("width")) {
+            polyline.setWidth((float)config.getDouble("width"));
+        }
+        if (config.hasKey("color")) {
+            try {
+                polyline.setColor(Color.parseColor(config.getString("color")));
+            } catch (Exception e) {
+                Log.i(REACT_CLASS, "- Failed to parse color: " + config.getString("color"));
+                e.printStackTrace();
+            }
+        }
+        if (config.hasKey("visible")) {
+            polyline.setVisible(config.getBoolean("visible"));
+        }
+        if (config.hasKey("zIndex")) {
+            polyline.setZIndex((float)config.getDouble("zIndex"));
+        }
+        if (config.hasKey("geodesic")) {
+            polyline.setGeodesic(config.getBoolean("geodesic"));
+        }
+    }
+
+    private Polyline findById(String id) {
+        for (Polyline polyline : polylines) {
+            if (polyline.getId().equals(id)) {
+                return polyline;
+            }
+        }
+        return null;
+    }
+}

--- a/android/app/src/main/java/com/rota/rngmaps/RNGMapsViewManager.java
+++ b/android/app/src/main/java/com/rota/rngmaps/RNGMapsViewManager.java
@@ -51,6 +51,9 @@ public class RNGMapsViewManager extends SimpleViewManager<MapView> {
         return REACT_CLASS;
     }
 
+    public GoogleMap getMap() {
+        return map;
+    }
     @Override
     protected MapView createViewInstance(ThemedReactContext context) {
         reactContext = context;

--- a/android/app/src/main/java/com/rota/rngmaps/RNGMapsViewManager.java
+++ b/android/app/src/main/java/com/rota/rngmaps/RNGMapsViewManager.java
@@ -1,0 +1,235 @@
+
+package com.rota.rngmaps;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.uimanager.CatalystStylesDiffMap;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIProp;
+import com.google.android.gms.maps.*;
+import com.google.android.gms.maps.model.BitmapDescriptorFactory;
+import com.google.android.gms.maps.model.CameraPosition;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.MarkerOptions;
+
+import java.util.ArrayList;
+
+/**
+ * Created by Henry on 08/10/2015.
+ */
+
+public class RNGMapsViewManager extends SimpleViewManager<MapView> {
+    public static final String REACT_CLASS = "RNGMapsViewManager";
+
+    private MapView mView;
+    private GoogleMap map;
+    private ReactContext reactContext;
+    private ArrayList<Marker> mapMarkers = new ArrayList<Marker>();
+
+    @UIProp(UIProp.Type.MAP)
+    public static final String PROP_CENTER = "center";
+
+    @UIProp(UIProp.Type.NUMBER)
+    public static final String PROP_ZOOM_LEVEL = "zoomLevel";
+
+    @UIProp(UIProp.Type.ARRAY)
+    public static final String PROP_MARKERS = "markers";
+
+    @UIProp(UIProp.Type.BOOLEAN)
+    public static final String PROP_ZOOM_ON_MARKERS = "zoomOnMarkers";
+
+    @Override
+    public String getName() {
+        return REACT_CLASS;
+    }
+
+    @Override
+    protected MapView createViewInstance(ThemedReactContext context) {
+        reactContext = context;
+        mView = new MapView(context);
+        mView.onCreate(null);
+        mView.onResume();
+        map = mView.getMap();
+
+        if (map == null) {
+          sendMapError("Map is null", "map_null");
+        } else {
+          map.getUiSettings().setMyLocationButtonEnabled(false);
+
+          try {
+              MapsInitializer.initialize(context.getApplicationContext());
+              map.setOnCameraChangeListener(getCameraChangeListener());
+          } catch (Exception e) {
+              e.printStackTrace();
+              sendMapError("Map initialize error", "map_init_error");
+          }
+        }
+
+        map.setMyLocationEnabled(true);
+        // We need to be sure to disable location-tracking when app enters background, in-case some other module
+        // has acquired a wake-lock and is controlling location-updates, otherwise, location-manager will be left
+        // updating location constantly, killing the battery, even though some other location-mgmt module may
+        // desire to shut-down location-services.
+        LifecycleEventListener listener = new LifecycleEventListener() {
+            @Override
+            public void onHostResume() {
+                map.setMyLocationEnabled(true);
+            }
+
+            @Override
+            public void onHostPause() {
+                map.setMyLocationEnabled(false);
+            }
+
+            @Override
+            public void onHostDestroy() {
+
+            }
+        };
+
+        context.addLifecycleEventListener(listener);
+
+        return mView;
+    }
+
+    private void sendMapError (String message, String type) {
+      WritableMap error = Arguments.createMap();
+      error.putString("message", message);
+      error.putString("type", type);
+
+      reactContext
+              .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+              .emit("mapError", error);
+    }
+
+    private GoogleMap.OnCameraChangeListener getCameraChangeListener() {
+        return new GoogleMap.OnCameraChangeListener() {
+            @Override
+            public void onCameraChange(CameraPosition position) {
+                WritableMap params = Arguments.createMap();
+                WritableMap latLng = Arguments.createMap();
+                latLng.putDouble("lat", position.target.latitude);
+                latLng.putDouble("lng", position.target.longitude);
+
+                params.putMap("latLng", latLng);
+                params.putDouble("zoomLevel", position.zoom);
+
+                reactContext
+                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                        .emit("mapChange", params);
+            }
+        };
+    }
+
+    private Boolean updateCenter (CatalystStylesDiffMap props) {
+        try {
+            CameraUpdate cameraUpdate;
+            Double lng = props.getMap(PROP_CENTER).getDouble("lng");
+            Double lat = props.getMap(PROP_CENTER).getDouble("lat");
+
+            if(props.hasKey(PROP_ZOOM_LEVEL)) {
+                int zoomLevel = props.getInt(PROP_ZOOM_LEVEL, 10);
+                cameraUpdate = CameraUpdateFactory
+                        .newLatLngZoom(
+                                new LatLng(lat, lng),
+                                props.getInt(PROP_ZOOM_LEVEL, 10)
+                        );
+            } else {
+                cameraUpdate = CameraUpdateFactory.newLatLng(new LatLng(lat, lng));
+            }
+
+            map.animateCamera(cameraUpdate);
+
+            return true;
+        } catch (Exception e) {
+            // ERROR!
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    public void addMarker(ReadableMap config) {
+        MarkerOptions options = createMarker(config);
+        mapMarkers.add(map.addMarker(options));
+    }
+    private MarkerOptions createMarker(ReadableMap config) {
+        MarkerOptions options = new MarkerOptions();
+        options.position(new LatLng(
+                        config.getMap("coordinates").getDouble("lat"),
+                        config.getMap("coordinates").getDouble("lng")
+                )
+        );
+        if(config.hasKey("title")) {
+            options.title(config.getString("title"));
+        }
+        if (config.hasKey("icon")) {
+            options.icon(BitmapDescriptorFactory.fromAsset(config.getString("icon")));
+        }
+        if (config.hasKey("anchor")) {
+            ReadableArray anchor = config.getArray("anchor");
+            options.anchor((float)anchor.getDouble(0), (float)anchor.getDouble(1));
+        }
+        return options;
+    }
+    private Boolean updateMarkers (CatalystStylesDiffMap props) {
+        try {
+            // First clear all markers from the map
+            for (Marker marker: mapMarkers) {
+                marker.remove();
+            }
+            mapMarkers.clear();
+
+            // All markers to map
+            for (int i = 0; i < props.getArray(PROP_MARKERS).size(); i++) {
+                ReadableMap config = props.getArray(PROP_MARKERS).getMap(i);
+                if(config.hasKey("coordinates")) {
+                    mapMarkers.add(map.addMarker(createMarker(config)));
+                } else break;
+            }
+
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private Boolean zoomOnMarkers () {
+        try {
+            int padding = 150;
+
+            LatLngBounds.Builder builder = new LatLngBounds.Builder();
+            for (Marker marker : mapMarkers) {
+                builder.include(marker.getPosition());
+            }
+            LatLngBounds bounds = builder.build();
+
+            CameraUpdate cu = CameraUpdateFactory.newLatLngBounds(bounds, padding);
+            map.animateCamera(cu);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    @Override
+    public void updateView(MapView view, CatalystStylesDiffMap props) {
+        super.updateView(view, props);
+        if (props.hasKey(PROP_CENTER)) updateCenter(props);
+        if (props.hasKey(PROP_ZOOM_LEVEL)) updateCenter(props);
+        if (props.hasKey(PROP_MARKERS)) updateMarkers(props);
+        if (props.hasKey(PROP_ZOOM_ON_MARKERS)&&props.getBoolean(PROP_ZOOM_ON_MARKERS, false)) {
+          zoomOnMarkers();
+        }
+
+    }
+}

--- a/index.android.js
+++ b/index.android.js
@@ -8,12 +8,15 @@ let {
   requireNativeComponent,
   PropTypes,
   DeviceEventEmitter,
+  NativeModules,
   Image
 } = React;
 
+var RNGMapsModule = NativeModules.RNGMapsModule;
+
 /* RNGMAPS COMP */
 var gmaps = {
-  name: 'RNGMaps',
+  name: 'RNGMapsViewManager',
   propTypes: {
     center: PropTypes.object,
     zoomLevel: PropTypes.number,
@@ -29,7 +32,7 @@ var gmaps = {
   },
 };
 
-let MapView = requireNativeComponent('RNGMaps', gmaps);
+let MapView = requireNativeComponent('RNGMapsViewManager', gmaps);
 
 class RNGMaps extends Component {
   constructor (props) {
@@ -59,11 +62,16 @@ class RNGMaps extends Component {
     this._error&&this._error.remove();
   }
 
+
   zoomOnMarkers (bool) {
     // HACK: Bleurgh, forcing the change on zoomOnMarkers.
     this.setState({ zoomOnMarkers: null }, () => {
       this.setState({ zoomOnMarkers: bool||true });
     });
+  }
+
+  addMarker (marker) {
+    RNGMapsModule.addMarker(marker);
   }
 
   updateMarkers (markers) {


### PR DESCRIPTION
- Introduce life-cycle-event-handler in order to toggle `map#setMyLocationEnabled` when app pauses / resumes.  This is important for other location-management modules which control location-services and desire to turn off location-services to conserve battery.  

- Also introduced a React bridge-module allowing the app code to execute methods upon the view instead of relying solely upon properties.  I wanted to be able to simply `addLocation(markerConfig)` instead of redrawing the entire list-of-markers each time I record a new location.  

- I've renamed the class `RNGMapsModule` to `RNGMapsViewManager`, since this class is not strictly a Module as it extends `SimpleViewManager`.  I've then claimed the name `RNGMapsModule` to implement the bridge-module.  

- Changed `play-services` dependency to import only `com.google.android.gms:play-services-maps` instead of including the entire, **immense** play-services library

