### PR TITLE
Lifecycle events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gmaps",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "React Native Android Google Maps implementation.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
While merging in react-native 16+ features of my last PR, I forgot to add the lifecycle event listener to **pause/resume** `map#setMyLocationEnabled`.

If this is not done, the gmap will keep GPS on **permanently**, killing the battery.  Map components should be subordinate to dedicated [geolocation modules](https://react.parts/native?search=location) (especially [mine](https://github.com/transistorsoft/react-native-background-geolocation) :) )

As you can see, this could easily be made configurable in the future if someone desires.