### PR TITLE
Fix `@ReactProp` in react-native `0.19.0`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,6 +23,6 @@ dependencies {
   compile fileTree(dir: 'libs', include: ['*.jar'])
   testCompile 'junit:junit:4.12'
   compile 'com.android.support:appcompat-v7:23.1.1'
-  compile 'com.facebook.react:react-native:0.16.+'
+  compile 'com.facebook.react:react-native:0.19.+'
   compile 'com.google.android.gms:play-services-maps:8.1.0'
 }

--- a/android/app/src/main/java/com/rota/rngmaps/RNGMapsViewManager.java
+++ b/android/app/src/main/java/com/rota/rngmaps/RNGMapsViewManager.java
@@ -14,9 +14,10 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ReactProp;
+
 import com.google.android.gms.maps.*;
 import com.google.android.gms.maps.model.*;
 


### PR DESCRIPTION
I experienced issue #16.  Found that **no** `@ReactProp` were working.  Found [this](https://github.com/facebook/react-native/issues/5649) and [this](https://github.com/lelandrichardson/react-native-maps/issues/59)

Fix is simple.  Update `build.gradle` to `0.19.+` then update the `ReactProp` dependency.

